### PR TITLE
Add persistent player history in QML

### DIFF
--- a/Desktop_GUI_QML/CMakeLists.txt
+++ b/Desktop_GUI_QML/CMakeLists.txt
@@ -10,6 +10,7 @@ qt_standard_project_setup(REQUIRES 6.8)
 
 qt_add_executable(appDesktop_GUI_QML
     main.cpp
+    PlayerHistory.cpp
 )
 
 qt_add_qml_module(appDesktop_GUI_QML

--- a/Desktop_GUI_QML/HomePage.qml
+++ b/Desktop_GUI_QML/HomePage.qml
@@ -66,9 +66,11 @@ Page {
                     height: 40
                     font.pixelSize: 16
                     background: Rectangle { color: root.accent; radius: 6 }
-                    onClicked: if (userField.text.trim().length > 0)
+                    onClicked: if (userField.text.trim().length > 0) {
+                                   historyModel.addPlayer(userField.text.trim())
                                    stack.push(Qt.resolvedUrl("ResultsPage.qml"),
                                               { username: userField.text.trim() })
+                               }
                 }
             }
         }
@@ -85,7 +87,5 @@ Page {
                 onClicked: stack.push(Qt.resolvedUrl("ResultsPage.qml"), { username: modelData })
             }
         }
-
-        ListModel { id: historyModel }
     }
 }

--- a/Desktop_GUI_QML/PlayerHistory.cpp
+++ b/Desktop_GUI_QML/PlayerHistory.cpp
@@ -1,0 +1,99 @@
+#include "PlayerHistory.h"
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+PlayerHistory::PlayerHistory(QObject *parent) : QAbstractListModel(parent)
+{
+    load();
+}
+
+int PlayerHistory::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_players.count();
+}
+
+QVariant PlayerHistory::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_players.size())
+        return QVariant();
+
+    if (role == NameRole || role == Qt::DisplayRole)
+        return m_players.at(index.row());
+
+    return QVariant();
+}
+
+void PlayerHistory::addPlayer(const QString &name)
+{
+    QString trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return;
+
+    int pos = m_players.indexOf(trimmed);
+    if (pos != -1)
+    {
+        if (pos == 0)
+            return; // already first
+        beginMoveRows(QModelIndex(), pos, pos, QModelIndex(), 0);
+        m_players.move(pos, 0);
+        endMoveRows();
+    }
+    else
+    {
+        beginInsertRows(QModelIndex(), m_players.size(), m_players.size());
+        m_players.append(trimmed);
+        endInsertRows();
+    }
+    save();
+}
+
+QStringList PlayerHistory::players() const
+{
+    return m_players;
+}
+
+void PlayerHistory::load()
+{
+    QFile file("player_history.json");
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    QByteArray data = file.readAll();
+    file.close();
+
+    auto doc = QJsonDocument::fromJson(data);
+    if (!doc.isArray())
+        return;
+
+    beginResetModel();
+    m_players.clear();
+    for (const QJsonValue &v : doc.array())
+    {
+        if (v.isString())
+            m_players.append(v.toString());
+    }
+    endResetModel();
+}
+
+void PlayerHistory::save() const
+{
+    QFile file("player_history.json");
+    if (!file.open(QIODevice::WriteOnly))
+        return;
+
+    QJsonArray arr;
+    for (const QString &name : m_players)
+        arr.append(name);
+    QJsonDocument doc(arr);
+    file.write(doc.toJson());
+    file.close();
+}
+
+QHash<int, QByteArray> PlayerHistory::roleNames() const
+{
+    return {{NameRole, "name"}};
+}
+

--- a/Desktop_GUI_QML/PlayerHistory.h
+++ b/Desktop_GUI_QML/PlayerHistory.h
@@ -1,0 +1,33 @@
+#ifndef PLAYERHISTORY_H
+#define PLAYERHISTORY_H
+
+#include <QAbstractListModel>
+#include <QStringList>
+
+class PlayerHistory : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    enum Roles {
+        NameRole = Qt::UserRole + 1
+    };
+
+    explicit PlayerHistory(QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    Q_INVOKABLE void addPlayer(const QString &name);
+    Q_INVOKABLE QStringList players() const;
+
+    void load();
+    void save() const;
+
+protected:
+    QHash<int, QByteArray> roleNames() const override;
+
+private:
+    QStringList m_players;
+};
+
+#endif // PLAYERHISTORY_H

--- a/Desktop_GUI_QML/main.cpp
+++ b/Desktop_GUI_QML/main.cpp
@@ -1,11 +1,15 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include "PlayerHistory.h"
 
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
+    PlayerHistory history;
+    engine.rootContext()->setContextProperty("historyModel", &history);
     QObject::connect(
         &engine,
         &QQmlApplicationEngine::objectCreationFailed,


### PR DESCRIPTION
## Summary
- implement a `PlayerHistory` C++ class for storing searched players
- expose the history model to QML
- save players to `player_history.json`
- update `HomePage.qml` to use the C++ model and keep history
- build system now compiles `PlayerHistory.cpp`

## Testing
- `cmake ..` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_b_68417297c10083328839f38e5ffe1ff3