### PR TITLE
Fix inconsistent ROI sd key for empty game sets

### DIFF
--- a/backend/app/analysis/longitudinal.py
+++ b/backend/app/analysis/longitudinal.py
@@ -68,10 +68,11 @@ def aggregate_roi(games_df: pd.DataFrame) -> Dict[str, float]:
         return {
             'roi_mean': 0.0,
             'roi_max': 0.0,
-            'roi_std': 0.0,
+            # Use consistent key name regardless of data availability
+            'roi_sd': 0.0,
             'roi_games>2': 0
         }
-    
+
     return {
         'roi_mean': roi_series.mean() if not roi_series.isna().all() else 0.0,
         'roi_max': roi_series.max() if not roi_series.isna().all() else 0.0,

--- a/test_aggregate_roi_sd.py
+++ b/test_aggregate_roi_sd.py
@@ -1,0 +1,20 @@
+import os, sys, importlib.util, pathlib
+import pandas as pd
+
+# Import the module directly from its file path to avoid importing the entire
+# application package, which attempts to connect to external services during
+# import time.
+module_path = pathlib.Path(__file__).with_name('backend') / 'app' / 'analysis' / 'longitudinal.py'
+spec = importlib.util.spec_from_file_location('longitudinal', module_path)
+longitudinal = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(longitudinal)  # type: ignore[attr-defined]
+
+aggregate_roi = longitudinal.aggregate_roi
+
+
+def test_empty_dataframe_returns_sd_key():
+    df = pd.DataFrame()
+    result = aggregate_roi(df)
+    assert 'roi_sd' in result
+    assert result['roi_sd'] == 0.0
+    assert 'roi_std' not in result


### PR DESCRIPTION
## Summary
- ensure `aggregate_roi` returns `roi_sd` key consistently, even when no games are present
- add regression test verifying empty DataFrame uses `roi_sd` and not `roi_std`

## Testing
- `pytest test_aggregate_roi_sd.py -q`
- `pytest -q` *(fails: No module named 'app.models', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a72cd4c9a88332827614bf2043b236