### PR TITLE
feat: probabilistic suspicion scoring

### DIFF
--- a/app/analysis/bayesian.py
+++ b/app/analysis/bayesian.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+"""Simple Bayesian model for computing suspicion probabilities."""
+
+from dataclasses import dataclass
+from typing import Dict, Callable, Optional
+
+
+@dataclass
+class BayesianSuspicionModel:
+    """Tiny Naive Bayes model for `P(suspicious | evidence)`.
+
+    The model is intentionally lightweight.  It provides a deterministic way
+    of combining a prior – based on rating and playing experience – with a set
+    of likelihood ratios derived from observed evidence (ACPL, timing metrics
+    …).  The goal is not to be statistically perfect but to have an extensible
+    place where new evidence can be plugged in easily.
+    """
+
+    # Base prior probability that a random game is suspicious
+    base_prior: float = 0.10
+
+    def _clamp(self, p: float) -> float:
+        return max(0.001, min(0.999, p))
+
+    # ------------------------------------------------------------------
+    # Priors
+    # ------------------------------------------------------------------
+    def compute_prior(self, rating: Optional[int], experience: int) -> float:
+        """Compute prior P(suspicious) from rating and experience.
+
+        Low rated or very inexperienced players get a slightly higher prior,
+        whereas experienced players get a lower prior.
+        """
+        p = self.base_prior
+        if rating:
+            # Players well above 2000 have a bit lower prior; beginners slightly higher
+            p += (1500 - rating) / 10000  # rating 2500 -> -0.1, rating 1000 -> +0.05
+        if experience:
+            p -= min(experience / 1000, 0.05)  # up to -0.05 for very experienced players
+        return self._clamp(p)
+
+    # ------------------------------------------------------------------
+    # Likelihoods
+    # ------------------------------------------------------------------
+    def _likelihood_ratio(self, feature: str, value: float) -> float:
+        """Return likelihood ratio P(evidence|suspicious)/P(evidence|not)."""
+        rules: Dict[str, Callable[[float], float]] = {
+            "acpl": lambda v: 5.0 if v < 20 else 1.0,
+            "match_rate": lambda v: 4.0 if v > 0.7 else 1.0,
+            "time_complexity_corr": lambda v: 3.0 if v < 0.1 else 1.0,
+            "lag_spike_count": lambda v: 2.0 if v > 2 else 1.0,
+            "opening_entropy": lambda v: 2.0 if v < 1.0 else 1.0,
+            "second_choice_rate": lambda v: 3.0 if v > 0.8 else 1.0,
+        }
+        func = rules.get(feature)
+        return func(value) if func else 1.0
+
+    # ------------------------------------------------------------------
+    def update(self, rating: Optional[int], experience: int, evidence: Dict[str, float]) -> float:
+        """Compute posterior probability given evidence."""
+        prior = self.compute_prior(rating, experience)
+        odds = prior / (1 - prior)
+        for name, value in evidence.items():
+            odds *= self._likelihood_ratio(name, value)
+        posterior = odds / (1 + odds)
+        return self._clamp(posterior)

--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -44,6 +44,7 @@ from app.analysis.timing import aggregate_time_management
 from app.analysis.quality import aggregate_clutch_accuracy
 from app.analysis.quality import aggregate_tactical_trends
 from app.analysis.endgame import aggregate_endgame_efficiency
+from .bayesian import BayesianSuspicionModel
 
 from app.analysis.quality import (
     aggregate_tactical_trends,
@@ -274,14 +275,14 @@ class ChessAnalysisEngine:
             timing_features = timing.aggregate_time_features(moves_df)
             logger.info(f"DEBUG ENGINE: Timing features: {timing_features}")
 
+            # Obtener todas las partidas del jugador para experiencia y, si aplica, análisis de apertura
+            games_df = self._get_player_games_df(username, session)
+            logger.info(f"DEBUG ENGINE: Player games DataFrame shape: {games_df.shape}")
+
             # 3. MÉTRICAS DE APERTURA (si es aplicable)
             opening_features = {}
             if self.reference_book:
                 logger.info("DEBUG ENGINE: Starting opening analysis with reference book")
-                # Necesitamos múltiples partidas del jugador para entropía
-                games_df = self._get_player_games_df(username, session)
-
-                logger.info(f"DEBUG ENGINE: Player games DataFrame shape: {games_df.shape}")
                 opening_features = openings.aggregate_opening_features(
                     game.opening_key or "",
                     game.eco_code,
@@ -313,10 +314,12 @@ class ChessAnalysisEngine:
             logger.info(f"DEBUG ENGINE: Combined features count: {len(all_features)}")
             logger.info(f"DEBUG ENGINE: All features: {all_features}")
 
-            # 6. CALCULAR FLAGS DE SOSPECHA
-            logger.info("DEBUG ENGINE: Calculating suspicious flags")
-            suspicious_flags = self._calculate_suspicious_flags(all_features)
-            logger.info(f"DEBUG ENGINE: Suspicious flags: {suspicious_flags}")
+            # 6. CALCULAR SCORE DE SOSPECHA
+            player_rating = game.white_elo if player_color == 'white' else game.black_elo
+            experience = len(games_df)
+            logger.info("DEBUG ENGINE: Calculating suspicion score")
+            suspicion_score = self._calculate_suspicion_score(all_features, player_rating, experience)
+            logger.info(f"DEBUG ENGINE: Suspicion score: {suspicion_score}")
 
             # 7. CREAR REGISTRO DE ANÁLISIS
             analysis = GameAnalysisDetailed(
@@ -341,8 +344,11 @@ class ChessAnalysisEngine:
                 # Endgame
                 tb_match_rate=all_features.get('tb_match_pct'),
                 conversion_efficiency=all_features.get('conversion_moves'),
-                # Flags
-                **suspicious_flags
+                # Flags (legacy fields kept for compatibility)
+                suspicious_quality=False,
+                suspicious_timing=False,
+                suspicious_opening=False,
+                overall_suspicion_score=suspicion_score,
             )
 
             session.add(analysis)
@@ -639,22 +645,18 @@ class ChessAnalysisEngine:
         return features
 
     @trace
-    def _calculate_suspicious_flags(self, features: Dict) -> Dict:
-        """Calcula flags de comportamiento sospechoso."""
-        return {
-            'suspicious_quality': (
-                    features.get('acpl', 100) < 20 and
-                    features.get('match_rate', 0) > 0.70
-            ),
-            'suspicious_timing': (
-                    features.get('time_complexity_corr', 1) < 0.1 or
-                    features.get('lag_spike_count', 0) > 2
-            ),
-            'suspicious_opening': (
-                    features.get('H_opening', 10) < 1.0 and
-                    features.get('second_choice_pct', 0) > 0.80
-            )
+    def _calculate_suspicion_score(self, features: Dict, rating: Optional[int], experience: int) -> float:
+        """Calcular ``P(suspicious | evidence)`` usando un modelo bayesiano simple."""
+        model = BayesianSuspicionModel()
+        evidence = {
+            'acpl': features.get('acpl', 0),
+            'match_rate': features.get('match_rate', 0),
+            'time_complexity_corr': features.get('time_complexity_corr', 0),
+            'lag_spike_count': features.get('lag_spike_count', 0),
+            'opening_entropy': features.get('H_opening', 0),
+            'second_choice_rate': features.get('second_choice_pct', 0),
         }
+        return model.update(rating, experience, evidence)
 
     @trace
     def _calculate_risk_score(self, games_df: pd.DataFrame,

--- a/app/api/v1/endpoints/analysis.py
+++ b/app/api/v1/endpoints/analysis.py
@@ -40,10 +40,7 @@ async def get_game_metrics(game_id: int, session: Session = Depends(get_session)
         "mean_move_time": detailed.mean_move_time,
         "time_variance": detailed.time_variance,
         "time_complexity_corr": detailed.time_complexity_corr,
-        "suspicious_quality": detailed.suspicious_quality,
-        "suspicious_timing": detailed.suspicious_timing,
-        "suspicious_opening": detailed.suspicious_opening,
-        "overall_suspicion_score": detailed.overall_suspicion_score,
+        "suspicion_score": detailed.overall_suspicion_score,
         "analyzed_at": detailed.analyzed_at.isoformat()
     }
 

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -56,6 +56,7 @@ from app.analysis import (
     aggregate_opening_features as o_feats,
     aggregate_endgame_features as e_feats,
 )
+from app.analysis.bayesian import BayesianSuspicionModel
 
 from kombu import Queue  # Añadido para configurar colas con prioridad
 from celery.exceptions import SoftTimeLimitExceeded
@@ -582,16 +583,19 @@ def analyze_game_detailed(game_id: int, username: str) -> dict[str, int | str | 
     except Exception:
         pass
 
-    quality_score = q.get("quality_score", 0) or 0  # None → 0
-    logger.info(f"DEBUG DETAILED: Quality score: {quality_score}")
-
-    overall_score = (
-            safe(quality_score) * 0.4 +
-            safe(t.get("timing_score")) * 0.25 +
-            safe(o.get("opening_score")) * 0.2 +
-            safe(e.get("endgame_score")) * 0.15
-    )
-    logger.info(f"DEBUG DETAILED: Overall suspicion score: {overall_score}")
+    model = BayesianSuspicionModel()
+    rating = game.white_elo if player_color == 'white' else game.black_elo
+    experience = len(games_df)
+    evidence = {
+        "acpl": q.get("acpl", 0),
+        "match_rate": q.get("match_rate", 0),
+        "time_complexity_corr": t.get("time_complexity_corr", 0),
+        "lag_spike_count": t.get("lag_spike_count", 0),
+        "opening_entropy": o.get("opening_entropy", 0),
+        "second_choice_rate": o.get("second_choice_rate", 0),
+    }
+    suspicion_score = model.update(rating, experience, evidence)
+    logger.info(f"DEBUG DETAILED: Bayesian suspicion score: {suspicion_score}")
 
     # ── 4. Persistir en BD ─────────────────────────────────────────────
     with Session(engine) as s:
@@ -622,10 +626,10 @@ def analyze_game_detailed(game_id: int, username: str) -> dict[str, int | str | 
             dtz_deviation=(None if (e.get("dtz_deviation") is None or (e.get("dtz_deviation") != e.get("dtz_deviation"))) else float(e.get("dtz_deviation"))),
             conversion_efficiency=(None if (e.get("conversion_efficiency") is None or (e.get("conversion_efficiency") != e.get("conversion_efficiency"))) else int(e.get("conversion_efficiency"))),
             # ─ Flags & score ─
-            suspicious_quality=bool(quality_score > 50),
-            suspicious_timing=bool((t.get("timing_score") or 0) > 50),
-            suspicious_opening=bool((o.get("opening_score") or 0) > 50),
-            overall_suspicion_score=safe(overall_score),
+            suspicious_quality=False,
+            suspicious_timing=False,
+            suspicious_opening=False,
+            overall_suspicion_score=safe(suspicion_score),
         )
         cancellation_key = f"cancel:{username}"
         if redis_client.get(cancellation_key):
@@ -644,7 +648,7 @@ def analyze_game_detailed(game_id: int, username: str) -> dict[str, int | str | 
         export_analysis_to_json(detailed, username, "game")
 
         # ⚠️  capturamos los valores **antes** de cerrar la sesión
-        suspicion_flag = overall_score > 50
+        suspicion_flag = suspicion_score > 0.5
         analyzed_at    = detailed.analyzed_at.isoformat()
 
     # ── 4. Actualizar progreso del jugador ─────────────────────────────
@@ -664,7 +668,7 @@ def analyze_game_detailed(game_id: int, username: str) -> dict[str, int | str | 
     result = {
         "game_id": game_id,
         "suspicious": suspicion_flag,
-        "score": round(overall_score, 1),
+        "score": round(suspicion_score, 3),
         "analyzed_at": analyzed_at,
     }
 

--- a/app/main.py
+++ b/app/main.py
@@ -621,11 +621,8 @@ def game_metrics(game_id: int, session: Session = Depends(get_session)):
         "tb_match_rate": ga.tb_match_rate,
         "dtz_deviation": ga.dtz_deviation,
         "conversion_efficiency": ga.conversion_efficiency,
-        # ── Flags y score ─────────────────────────
-        "suspicious_quality": ga.suspicious_quality,
-        "suspicious_timing": ga.suspicious_timing,
-        "suspicious_opening": ga.suspicious_opening,
-        "overall_suspicion_score": ga.overall_suspicion_score,
+        # ── Score de sospecha ─────────────────────
+        "suspicion_score": ga.overall_suspicion_score,
         # ── Metadata ──────────────────────────────
         "analyzed_at": ga.analyzed_at.isoformat(),
     }

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -450,14 +450,12 @@ class GameMetricsOut(BaseModel):
     mean_move_time: float
     time_variance: float
     time_complexity_corr: float
-    suspicious_quality: float
-    suspicious_timing: float
-    suspicious_opening: float
-    overall_suspicion_score: float
+    suspicion_score: float = Field(alias="overall_suspicion_score")
     analyzed_at: datetime
 
     class Config:
         orm_mode = True
+        allow_population_by_field_name = True
         schema_extra = {
             "example": {
                 "game_id": 42,
@@ -470,10 +468,7 @@ class GameMetricsOut(BaseModel):
                 "mean_move_time": 12.5,
                 "time_variance": 30.2,
                 "time_complexity_corr": 0.45,
-                "suspicious_quality": 0.1,
-                "suspicious_timing": 0.2,
-                "suspicious_opening": 0.05,
-                "overall_suspicion_score": 0.12,
+                "suspicion_score": 0.12,
                 "analyzed_at": "2024-06-28T15:00:00Z"
             }
         }


### PR DESCRIPTION
## Summary
- replace heuristic flags with BayesianSuspicionModel computing P(suspicious | evidence)
- expose suspicion_score across API and schemas
- store Bayesian suspicion score in celery workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2acab14c83328dd4099e043e9677