### PR TITLE
Integrate supervised ML classifier for suspicion scoring

### DIFF
--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -45,6 +45,7 @@ from app.analysis.quality import aggregate_clutch_accuracy
 from app.analysis.quality import aggregate_tactical_trends
 from app.analysis.endgame import aggregate_endgame_efficiency
 from .bayesian import BayesianSuspicionModel
+from .ml_classifier import MLSuspicionClassifier
 
 from app.analysis.quality import (
     aggregate_tactical_trends,
@@ -646,8 +647,10 @@ class ChessAnalysisEngine:
 
     @trace
     def _calculate_suspicion_score(self, features: Dict, rating: Optional[int], experience: int) -> float:
-        """Calcular ``P(suspicious | evidence)`` usando un modelo bayesiano simple."""
-        model = BayesianSuspicionModel()
+        """Combina modelos bayesianos y supervisados para un score final."""
+
+        # --- Modelo bayesiano -------------------------------------------------
+        bayes_model = BayesianSuspicionModel()
         evidence = {
             'acpl': features.get('acpl', 0),
             'match_rate': features.get('match_rate', 0),
@@ -656,7 +659,19 @@ class ChessAnalysisEngine:
             'opening_entropy': features.get('H_opening', 0),
             'second_choice_rate': features.get('second_choice_pct', 0),
         }
-        return model.update(rating, experience, evidence)
+        bayes_prob = bayes_model.update(rating, experience, evidence)
+
+        # --- Clasificador supervisado ---------------------------------------
+        ml_prob = bayes_prob
+        try:
+            ml_clf = MLSuspicionClassifier()
+            ml_prob = ml_clf.predict_proba(features)
+        except Exception as exc:
+            logger.warning("ML classifier unavailable: %s", exc)
+
+        # Soft voting: media de ambas probabilidades
+        final_prob = (bayes_prob + ml_prob) / 2
+        return final_prob
 
     @trace
     def _calculate_risk_score(self, games_df: pd.DataFrame,

--- a/app/analysis/ml_classifier.py
+++ b/app/analysis/ml_classifier.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""Supervised classifier pipeline for suspicion analysis.
+
+This module provides a thin wrapper around a scikit-learn model that
+uses the existing game metrics as features.  It supports training with
+cross-validation, prediction of probabilities, and persistence of the
+trained model under ``models/``.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.model_selection import StratifiedKFold, cross_val_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+
+MODEL_FILENAME = "ml_suspicion_model.pkl"
+
+
+@dataclass
+class MLSuspicionClassifier:
+    """Wrapper around a scikit-learn classifier for suspicious behaviour.
+
+    The classifier expects a set of numerical features describing a
+    game.  Features correspond to the metrics computed by the analysis
+    engine (ACPL, match_rate, timing correlations, etc.).
+
+    The model is persisted under ``models/`` relative to the repository
+    root so it can be reused across sessions.
+    """
+
+    model_path: Optional[Path] = None
+    model: Optional[Pipeline] = None
+    feature_names: Optional[Iterable[str]] = None
+
+    def __post_init__(self) -> None:
+        if self.model_path is None:
+            repo_root = Path(__file__).resolve().parents[2]
+            self.model_path = repo_root / "models" / MODEL_FILENAME
+        if self.model_path.exists():
+            data = joblib.load(self.model_path)
+            self.model = data["model"]
+            self.feature_names = data.get("features")
+
+    # ------------------------------------------------------------------
+    def train(
+        self,
+        X: pd.DataFrame,
+        y: Iterable[int],
+        model_type: str = "random_forest",
+        cv: int = 5,
+    ) -> Dict[str, float]:
+        """Train the classifier and persist it to disk.
+
+        Parameters
+        ----------
+        X:
+            DataFrame containing feature columns.
+        y:
+            Iterable with binary labels (1 suspicious, 0 clean).
+        model_type:
+            Either ``"random_forest"`` or ``"gradient_boosting"``.
+        cv:
+            Number of folds for cross-validation.
+
+        Returns
+        -------
+        Dict with cross-validation statistics.
+        """
+
+        if model_type == "gradient_boosting":
+            estimator = GradientBoostingClassifier(random_state=42)
+        else:
+            estimator = RandomForestClassifier(
+                n_estimators=200, random_state=42
+            )
+
+        pipeline = Pipeline([
+            ("scaler", StandardScaler()),
+            ("clf", estimator),
+        ])
+
+        cv_strategy = StratifiedKFold(n_splits=cv, shuffle=True, random_state=42)
+        scores = cross_val_score(
+            pipeline, X, y, cv=cv_strategy, scoring="roc_auc"
+        )
+
+        pipeline.fit(X, y)
+        self.model = pipeline
+        self.feature_names = list(X.columns)
+
+        # Persist model and feature ordering
+        self.model_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump({"model": self.model, "features": self.feature_names}, self.model_path)
+
+        return {"cv_mean": float(scores.mean()), "cv_std": float(scores.std())}
+
+    # ------------------------------------------------------------------
+    def predict_proba(self, features: Dict[str, float]) -> float:
+        """Predict probability of being suspicious for a single set of features."""
+        if self.model is None:
+            if not self.model_path or not self.model_path.exists():
+                raise FileNotFoundError(
+                    "Trained model not found. Train the classifier first."
+                )
+            data = joblib.load(self.model_path)
+            self.model = data["model"]
+            self.feature_names = data.get("features")
+
+        assert self.feature_names is not None
+        row = [features.get(name, 0.0) for name in self.feature_names]
+        X = pd.DataFrame([row], columns=self.feature_names)
+        proba = self.model.predict_proba(X)[0, 1]
+        return float(proba)


### PR DESCRIPTION
## Summary
- Add `MLSuspicionClassifier` implementing supervised pipeline with cross-validation and model persistence
- Combine Bayesian and ML classifier probabilities via soft voting in analysis engine

## Testing
- `pytest -q`
- `python -m py_compile app/analysis/ml_classifier.py app/analysis/engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7f7bc3c08332a93d51c7002d9bc0