### PR TITLE
Add change point detection and period segmentation

### DIFF
--- a/app/analysis/change_point.py
+++ b/app/analysis/change_point.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import t
+from typing import Iterable, List
+
+
+def cusum_change_points(series: Iterable[float], threshold: float | None = None, drift: float = 0.0) -> List[int]:
+    """Detect change points using a simple two-sided CUSUM algorithm.
+
+    Parameters
+    ----------
+    series : iterable of float
+        Time series data.
+    threshold : float, optional
+        Threshold for the cumulative sum. If ``None`` it is set to ``5 * sd``.
+    drift : float, optional
+        Expected drift between observations.
+
+    Returns
+    -------
+    list[int]
+        Indices where a change point is detected.
+    """
+    values = pd.Series(series).dropna().to_numpy()
+    if len(values) < 2:
+        return []
+    if threshold is None:
+        threshold = 5 * np.std(values)
+    pos_sum = 0.0
+    neg_sum = 0.0
+    change_points: List[int] = []
+    for i in range(1, len(values)):
+        diff = values[i] - values[i - 1] - drift
+        pos_sum = max(0.0, pos_sum + diff)
+        neg_sum = min(0.0, neg_sum + diff)
+        if pos_sum > threshold or neg_sum < -threshold:
+            change_points.append(i)
+            pos_sum = 0.0
+            neg_sum = 0.0
+    return change_points
+
+
+def bayesian_online_change_points(series: Iterable[float], hazard_lambda: float = 250) -> List[int]:
+    """Bayesian online change point detection (Adams & MacKay, 2007).
+
+    Parameters
+    ----------
+    series : iterable of float
+        Time series data.
+    hazard_lambda : float, optional
+        Parameter for the constant hazard function (larger → less frequent changes).
+
+    Returns
+    -------
+    list[int]
+        Indices of probable change points.
+    """
+    data = pd.Series(series).dropna().to_numpy()
+    n = len(data)
+    if n == 0:
+        return []
+
+    R = np.zeros((n + 1, n + 1))
+    R[0, 0] = 1
+
+    mu0, kappa0, alpha0, beta0 = 0.0, 1.0, 1.0, 1.0
+    mu = np.full(n + 1, mu0)
+    kappa = np.full(n + 1, kappa0)
+    alpha = np.full(n + 1, alpha0)
+    beta = np.full(n + 1, beta0)
+
+    hazard = 1.0 / hazard_lambda
+    change_points: List[int] = []
+
+    for t_idx, x in enumerate(data, start=1):
+        pred_mean = mu[:t_idx]
+        pred_kappa = kappa[:t_idx]
+        pred_alpha = alpha[:t_idx]
+        pred_beta = beta[:t_idx]
+
+        pred_var = pred_beta * (pred_kappa + 1) / (pred_alpha * pred_kappa)
+        pred_probs = t.pdf(x, df=2 * pred_alpha, loc=pred_mean, scale=np.sqrt(pred_var))
+
+        growth_probs = pred_probs * R[:t_idx, t_idx - 1] * (1 - hazard)
+        cp_prob = np.sum(pred_probs * R[:t_idx, t_idx - 1] * hazard)
+
+        R[1:t_idx + 1, t_idx] = growth_probs
+        R[0, t_idx] = cp_prob
+        R[:t_idx + 1, t_idx] /= np.sum(R[:t_idx + 1, t_idx])
+
+        mu[1:t_idx + 1] = (pred_kappa * pred_mean + x) / (pred_kappa + 1)
+        kappa[1:t_idx + 1] = pred_kappa + 1
+        alpha[1:t_idx + 1] = pred_alpha + 0.5
+        beta[1:t_idx + 1] = pred_beta + (pred_kappa * (x - pred_mean) ** 2) / (2 * (pred_kappa + 1))
+
+        if R[0, t_idx] > 0.5:
+            change_points.append(t_idx - 1)
+
+    return change_points
+
+
+def detect_change_points(series: Iterable[float], threshold: float | None = None, hazard_lambda: float = 250) -> List[int]:
+    """Combine CUSUM and Bayesian detectors for a robust set of change points."""
+    cusum_cps = cusum_change_points(series, threshold=threshold)
+    bayes_cps = bayesian_online_change_points(series, hazard_lambda=hazard_lambda)
+    return sorted(set(cusum_cps + bayes_cps))

--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -549,7 +549,6 @@ class ChessAnalysisEngine:
 
             time_patterns = clean_json_numbers(long_features.get("time_patterns"))
             opening_patterns = clean_json_numbers(long_features.get("opening_patterns"))
-            performance = clean_json_numbers(long_features.get("performance"))
             phase_quality = clean_json_numbers(long_features.get("phase_quality"))
             benchmark = clean_json_numbers(long_features.get("benchmark"))
             time_mgmt = clean_json_numbers(long_features.get("time_management"))
@@ -560,6 +559,8 @@ class ChessAnalysisEngine:
             performance = clean_json_numbers(long_features.get("performance"))
             risk_factors = clean_json_numbers(risk_factors)
             time_patterns = clean_json_numbers(time_patterns)
+            segments = clean_json_numbers(long_features.get("segments"))
+            change_points = long_features.get("change_points", [])
             # ── 4. Estadísticos globales y objeto PlayerAnalysisDetailed ─────
             analysis = models.PlayerAnalysisDetailed(
                 username=username,
@@ -594,6 +595,8 @@ class ChessAnalysisEngine:
                 tactical=tactical,
                 time_complexity=time_complexity,
                 endgame=endgame_feats,
+                segments=segments,
+                change_points=change_points,
                 # ─ Riesgo ─
                 risk_score=risk_score,
                 risk_factors=risk_factors,

--- a/app/analysis/longitudinal.py
+++ b/app/analysis/longitudinal.py
@@ -5,6 +5,7 @@ import numpy as np
 from typing import Dict, Tuple
 import logging
 from scipy.stats import linregress
+from .change_point import detect_change_points
 logger = logging.getLogger(__name__)
 
 
@@ -242,6 +243,48 @@ def longest_streak(roi_series: pd.Series,
     return int(max_streak) if not pd.isna(max_streak) and not np.isnan(max_streak) else 0
 
 
+###############################################################################
+# 6.  SEGMENTACIÓN POR PUNTOS DE CAMBIO ########################################
+###############################################################################
+@trace
+def segment_history(games_df: pd.DataFrame) -> Dict[str, list]:
+    """Segmenta el historial detectando puntos de cambio en ACPL y tiempo.
+
+    Usa una combinación de CUSUM y el algoritmo bayesiano de Adams & MacKay
+    para localizar cambios en la media de ``acpl`` y ``mean_move_time``.
+
+    Parameters
+    ----------
+    games_df : pd.DataFrame
+        DataFrame de partidas ordenado cronológicamente.
+
+    Returns
+    -------
+    dict
+        {'segments': list[dict], 'change_points': list[int]}
+    """
+    if games_df.empty:
+        return {"segments": [], "change_points": []}
+
+    cp_acpl = detect_change_points(games_df.get("acpl", [])) if "acpl" in games_df else []
+    cp_time = detect_change_points(games_df.get("mean_move_time", [])) if "mean_move_time" in games_df else []
+    cps = sorted(set(cp_acpl + cp_time))
+
+    segments = []
+    start = 0
+    for cp in cps + [len(games_df)]:
+        seg = games_df.iloc[start:cp]
+        segment_info = {
+            "start": int(start),
+            "end": int(cp),
+            "mean_acpl": float(seg["acpl"].mean()) if "acpl" in seg.columns and not seg["acpl"].isna().all() else None,
+            "mean_time": float(seg["mean_move_time"].mean()) if "mean_move_time" in seg.columns and not seg["mean_move_time"].isna().all() else None,
+        }
+        segments.append(segment_info)
+        start = cp
+
+    return {"segments": segments, "change_points": cps}
+
 @trace
 def compute_trends(games_df: pd.DataFrame) -> dict:
     """
@@ -347,6 +390,12 @@ def aggregate_longitudinal_features(
     step_acpl_features = detect_step_function(games_df, aliases=("acpl",), min_delta=25)
     features.update(step_acpl_features)
     logger.info(f"DEBUG LONGITUDINAL: ACPL step function features: {step_acpl_features}")
+
+    # --- Change point segmentation ------------------------------------
+    logger.info("DEBUG LONGITUDINAL: Segmenting history for change points")
+    segmentation = segment_history(games_df)
+    features.update(segmentation)
+    logger.info(f"DEBUG LONGITUDINAL: Segmentation result: {segmentation}")
 
     # --- Selectivity ------------------------------------------------------
     logger.info("DEBUG LONGITUDINAL: Calculating selectivity score")

--- a/app/models.py
+++ b/app/models.py
@@ -232,6 +232,8 @@ class PlayerAnalysisDetailed(SQLModel, table=True):
     endgame: Dict | None = Field(sa_column=Column(JSON, default=dict))
 
     time_complexity: Dict | None = Field(sa_column=Column(JSON, default=dict))
+    segments: list[Dict] = Field(sa_column=Column(JSON, default=list))
+    change_points: list[int] = Field(sa_column=Column(JSON, default=list))
     # back-ref al jugador
     player: Optional[Player] = Relationship(back_populates="analysis")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -169,6 +169,25 @@ class PhaseQualityOut(BaseModel):
                 "middlegame_blunder_rate": 0.07,
                 "endgame_blunder_rate": 0.03,
                 "blunder_rate": 0.05
+        }
+        }
+
+
+class SegmentOut(BaseModel):
+    """Segmento temporal del historial del jugador."""
+
+    start: int
+    end: int
+    mean_acpl: Optional[float] = None
+    mean_time: Optional[float] = None
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "start": 0,
+                "end": 50,
+                "mean_acpl": 35.2,
+                "mean_time": 12.3,
             }
         }
 
@@ -240,6 +259,8 @@ class PlayerMetricsOut(BaseModel):
     selectivity_score: float
     time_patterns: Optional[TimePatternsOut] = None
     opening_patterns: Optional[OpeningPatternsOut] = None
+    segments: Optional[List[SegmentOut]] = None
+    change_points: Optional[List[int]] = None
 
     trend_acpl: float | None = None
     trend_match_rate: float | None = None
@@ -296,6 +317,10 @@ class PlayerMetricsOut(BaseModel):
                     "opening_breadth": 40,
                     "second_choice_rate": 0.19
                 },
+                "segments": [
+                    {"start": 0, "end": 40, "mean_acpl": 45.0, "mean_time": 15.2}
+                ],
+                "change_points": [40],
                 "trend_acpl": -1.4,
                 "trend_match_rate": 0.03,
                 "roi_curve": [0.01, -0.02, 0.03],


### PR DESCRIPTION
## Summary
- implement CUSUM and Bayesian change-point detectors
- segment player history into stable periods
- persist detected segments and change points in analysis outputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab87a2e9f8833284348b973387e955