### PR TITLE
Add performance modeling for longitudinal analysis

### DIFF
--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -10,6 +10,7 @@ from . import endgame
 from . import longitudinal
 from . import spc
 from .engine import ChessAnalysisEngine, prepare_moves_dataframe
+from .performance_model import fit_performance_model, predict_performance
 
 from .quality   import aggregate_quality_features
 from .timing    import aggregate_time_features
@@ -31,4 +32,6 @@ __all__ = [
     'aggregate_opening_features',
     'aggregate_endgame_features',
     'compute_spc',
+    'fit_performance_model',
+    'predict_performance',
 ]

--- a/app/analysis/longitudinal.py
+++ b/app/analysis/longitudinal.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 from app.utils_debugging.tracer import trace
 from .spc import compute_spc
+from .performance_model import fit_performance_model, predict_performance
 
 ###############################################################################
 # 0.  CONSTANTES Y UTILIDADES ##################################################
@@ -370,6 +371,34 @@ def aggregate_longitudinal_features(
     roi_features = aggregate_roi(games_df)
     features.update(roi_features)
     logger.info(f"DEBUG LONGITUDINAL: ROI features: {roi_features}")
+
+    # --- Performance model predictions for ROI ---------------------------
+    try:
+        roi_valid = roi_series.dropna()
+        if len(roi_valid) >= 2:
+            roi_model = fit_performance_model(roi_valid, model="arima")
+            roi_pred = predict_performance(roi_model, steps=1)[0]
+            roi_resid = roi_valid.iloc[-1] - roi_pred
+            features["roi_pred"] = float(roi_pred)
+            features["roi_resid"] = float(roi_resid)
+            if len(roi_valid) > 1:
+                features["roi_resid_alert"] = bool(abs(roi_resid) > 2 * roi_valid.std(ddof=1))
+    except Exception as e:
+        logger.warning(f"DEBUG LONGITUDINAL: ROI performance model failed: {e}")
+
+    # --- Performance model predictions for ACPL --------------------------
+    try:
+        acpl_series_model = pd.to_numeric(games_df.get("acpl"), errors="coerce").dropna()
+        if len(acpl_series_model) >= 2:
+            acpl_model = fit_performance_model(acpl_series_model, model="kalman")
+            acpl_pred = predict_performance(acpl_model, steps=1)[0]
+            acpl_resid = acpl_series_model.iloc[-1] - acpl_pred
+            features["acpl_pred"] = float(acpl_pred)
+            features["acpl_resid"] = float(acpl_resid)
+            if len(acpl_series_model) > 1:
+                features["acpl_resid_alert"] = bool(abs(acpl_resid) > 2 * acpl_series_model.std(ddof=1))
+    except Exception as e:
+        logger.warning(f"DEBUG LONGITUDINAL: ACPL performance model failed: {e}")
     
     longest_roi_streak = longest_streak(roi_series)
     features['longest_streak'] = longest_roi_streak

--- a/app/analysis/longitudinal.py
+++ b/app/analysis/longitudinal.py
@@ -388,7 +388,8 @@ def aggregate_longitudinal_features(
 
     # --- Performance model predictions for ACPL --------------------------
     try:
-        acpl_series_model = pd.to_numeric(games_df.get("acpl"), errors="coerce").dropna()
+        acpl_values = games_df.get("acpl")
+        acpl_series_model = pd.to_numeric(pd.Series(acpl_values), errors="coerce").dropna()
         if len(acpl_series_model) >= 2:
             acpl_model = fit_performance_model(acpl_series_model, model="kalman")
             acpl_pred = predict_performance(acpl_model, steps=1)[0]
@@ -448,11 +449,16 @@ def aggregate_longitudinal_features(
     else:
         acpl_raw = games_df.get("acl")
     acpl_series = (
-        pd.to_numeric(acpl_raw, errors="coerce")
+        pd.to_numeric(pd.Series(acpl_raw), errors="coerce")
         if acpl_raw is not None
         else pd.Series(dtype=float)
     )
-    time_series = pd.to_numeric(games_df.get("mean_move_time"), errors="coerce")
+    time_raw = games_df.get("mean_move_time")
+    time_series = (
+        pd.to_numeric(pd.Series(time_raw), errors="coerce")
+        if time_raw is not None
+        else pd.Series(dtype=float)
+    )
     spc_acpl = compute_spc(acpl_series) if not acpl_series.dropna().empty else {}
     spc_time = compute_spc(time_series) if not time_series.dropna().empty else {}
     if spc_acpl:

--- a/app/analysis/longitudinal.py
+++ b/app/analysis/longitudinal.py
@@ -443,7 +443,15 @@ def aggregate_longitudinal_features(
 
     # --- SPC Charts ------------------------------------------------------
     logger.info("DEBUG LONGITUDINAL: Calculating SPC charts")
-    acpl_series = pd.to_numeric(games_df.get("acpl") or games_df.get("acl"), errors="coerce")
+    if "acpl" in games_df.columns:
+        acpl_raw = games_df["acpl"]
+    else:
+        acpl_raw = games_df.get("acl")
+    acpl_series = (
+        pd.to_numeric(acpl_raw, errors="coerce")
+        if acpl_raw is not None
+        else pd.Series(dtype=float)
+    )
     time_series = pd.to_numeric(games_df.get("mean_move_time"), errors="coerce")
     spc_acpl = compute_spc(acpl_series) if not acpl_series.dropna().empty else {}
     spc_time = compute_spc(time_series) if not time_series.dropna().empty else {}

--- a/app/analysis/performance_model.py
+++ b/app/analysis/performance_model.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+from typing import Dict
+
+
+def fit_performance_model(series: pd.Series, model: str = "arima") -> Dict[str, float]:
+    """Fit a simple time-series model for performance metrics.
+
+    Parameters
+    ----------
+    series : pd.Series
+        Series of historical metric values (ACPL, ROI, etc.).
+    model : str
+        Type of model to fit. Options: ``"arima"`` or ``"kalman"``.
+
+    Returns
+    -------
+    dict
+        Dictionary containing fitted parameters and model type.
+    """
+    s = pd.Series(series).dropna().astype(float)
+    if s.empty:
+        raise ValueError("series must contain data")
+
+    if model == "arima":
+        if len(s) < 2:
+            phi = 0.0
+            c = float(s.iloc[-1])
+        else:
+            y = s.iloc[1:].values
+            X = np.vstack([np.ones(len(y)), s.iloc[:-1].values]).T
+            c, phi = np.linalg.lstsq(X, y, rcond=None)[0]
+        return {"model": "arima", "phi": float(phi), "c": float(c), "last": float(s.iloc[-1])}
+
+    if model == "kalman":
+        x = float(s.iloc[0])
+        p = 1.0
+        q = float(np.var(s.diff().dropna(), ddof=1) or 1.0)
+        r = float((np.var(s, ddof=1) * 0.1) or 1.0)
+        for z in s:
+            p = p + q
+            k = p / (p + r)
+            x = x + k * (z - x)
+            p = (1 - k) * p
+        return {"model": "kalman", "state": float(x), "p": float(p), "q": float(q), "r": float(r)}
+
+    raise ValueError("model must be 'arima' or 'kalman'")
+
+
+def predict_performance(model: Dict[str, float], steps: int = 1) -> np.ndarray:
+    """Generate forward predictions from a fitted model."""
+    if model.get("model") == "arima":
+        last = model["last"]
+        phi = model["phi"]
+        c = model["c"]
+        preds = []
+        for _ in range(steps):
+            last = c + phi * last
+            preds.append(last)
+        return np.array(preds)
+
+    if model.get("model") == "kalman":
+        state = model["state"]
+        return np.full(steps, state)
+
+    raise ValueError("unknown model type")


### PR DESCRIPTION
## Summary
- Implement simple ARIMA and Kalman-based performance modeling utilities
- Expose `fit_performance_model` and `predict_performance` via analysis package
- Integrate predictions and residual alerts into longitudinal feature pipeline

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac059f301c8332b2200a54b617dfb9