### PR TITLE
Add anomaly detection score to analysis pipeline

### DIFF
--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -9,6 +9,7 @@ from . import openings
 from . import endgame
 from . import longitudinal
 from . import spc
+from . import anomaly
 from .engine import ChessAnalysisEngine, prepare_moves_dataframe
 from .performance_model import fit_performance_model, predict_performance
 
@@ -16,6 +17,7 @@ from .quality   import aggregate_quality_features
 from .timing    import aggregate_time_features
 from .openings  import aggregate_opening_features
 from .endgame   import aggregate_endgame_features
+from .anomaly   import aggregate_anomaly_features
 from .spc       import compute_spc
 
 __all__ = [
@@ -25,12 +27,14 @@ __all__ = [
     'endgame',
     'longitudinal',
     'spc',
+    'anomaly',
     'prepare_moves_dataframe',
     'ChessAnalysisEngine',
     'aggregate_quality_features',
     'aggregate_time_features',
     'aggregate_opening_features',
     'aggregate_endgame_features',
+    'aggregate_anomaly_features',
     'compute_spc',
     'fit_performance_model',
     'predict_performance',

--- a/app/analysis/anomaly.py
+++ b/app/analysis/anomaly.py
@@ -1,0 +1,154 @@
+"""Anomaly detection utilities for chess game analysis.
+
+This module provides several anomaly detection methods that can be
+applied to per-move time series extracted from a single game. The
+current implementation exposes:
+
+* :func:`stl_residual_zscores` – uses Seasonal-Trend decomposition
+  (STL) to isolate residuals and returns their z-scores. This helps
+  highlighting abrupt changes once trend/seasonality have been
+  removed.
+* :func:`isolation_forest_scores` – runs an Isolation Forest model on
+  rolling window features to detect unusual behaviour patterns.
+* :func:`aggregate_anomaly_features` – convenience wrapper used by the
+  analysis pipeline. It combines the previous methods and returns a
+  single ``anomaly_score`` for the game.
+
+An optional ``lstm_autoencoder_scores`` stub is provided in case a
+sequence autoencoder is implemented in the future.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+try:  # statsmodels is only needed for the STL decomposition
+    from statsmodels.tsa.seasonal import STL
+except Exception:  # pragma: no cover - fallback when statsmodels unavailable
+    STL = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def stl_residual_zscores(series: pd.Series, period: int = 10) -> pd.Series:
+    """Return z-scores of the residuals after STL decomposition.
+
+    Parameters
+    ----------
+    series:
+        Time series to analyse (e.g. per-move times).
+    period:
+        Seasonal period passed to :class:`~statsmodels.tsa.seasonal.STL`.
+
+    Returns
+    -------
+    pandas.Series
+        Z-scores of the residual component. Empty if decomposition is
+        not possible (e.g. not enough data or statsmodels missing).
+    """
+
+    series = series.dropna()
+    if STL is None or len(series) < period * 2:
+        logger.debug("STL decomposition skipped – insufficient data or library")
+        return pd.Series(dtype=float)
+
+    stl = STL(series, period=period, robust=True)
+    res = stl.fit()
+    resid = res.resid
+    if resid.std(ddof=0) == 0:
+        return pd.Series(np.zeros_like(resid), index=resid.index)
+    zscores = (resid - resid.mean()) / resid.std(ddof=0)
+    return pd.Series(zscores, index=resid.index)
+
+
+def isolation_forest_scores(features: pd.DataFrame, contamination: float = 0.1) -> np.ndarray:
+    """Compute Isolation Forest anomaly scores for the given features.
+
+    Parameters
+    ----------
+    features:
+        DataFrame containing rolling window features.
+    contamination:
+        Expected proportion of anomalies in the data.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of anomaly scores where higher values indicate more
+        anomalous observations. Returns an empty array if there are not
+        enough samples for training.
+    """
+
+    if features.empty or len(features) < 10:
+        logger.debug("Isolation Forest skipped – insufficient data")
+        return np.array([])
+
+    model = IsolationForest(
+        n_estimators=100,
+        contamination=contamination,
+        random_state=42,
+    )
+    model.fit(features)
+    scores = -model.decision_function(features)
+    return scores
+
+
+def lstm_autoencoder_scores(series: pd.Series) -> np.ndarray:
+    """Placeholder for an LSTM autoencoder based anomaly score.
+
+    Currently this function returns an empty array. It exists to make
+    future extensions straightforward without changing the public API.
+    """
+
+    # An actual implementation would go here using libraries such as
+    # TensorFlow or PyTorch. For now we simply return an empty array and
+    # log the fact that the method is not implemented.
+    logger.debug("LSTM autoencoder not implemented")
+    return np.array([])
+
+
+def aggregate_anomaly_features(moves_df: pd.DataFrame) -> Dict[str, float]:
+    """Aggregate anomaly related features for a game.
+
+    Parameters
+    ----------
+    moves_df:
+        DataFrame with per-move information. The function expects at
+        least ``move_time`` and ``cp_loss`` columns to be present.
+
+    Returns
+    -------
+    dict
+        ``{"anomaly_score": float}`` combining different detection
+        methods. A score of ``0.0`` denotes no detected anomalies.
+    """
+
+    if moves_df.empty:
+        return {"anomaly_score": 0.0}
+
+    # --- STL based z-scores -------------------------------------------------
+    zscores = stl_residual_zscores(moves_df.get("move_time", pd.Series(dtype=float)))
+    max_abs_z = float(np.abs(zscores).max()) if not zscores.empty else 0.0
+
+    # --- Isolation Forest on rolling window features -----------------------
+    window = 5
+    features = pd.DataFrame({
+        "cp_loss_mean": moves_df["cp_loss"].rolling(window).mean(),
+        "move_time_std": moves_df["move_time"].rolling(window).std(),
+    }).dropna()
+    iso_scores = isolation_forest_scores(features)
+    iso_max = float(iso_scores.max()) if iso_scores.size else 0.0
+
+    anomaly_score = max_abs_z + iso_max
+    logger.debug(
+        "Anomaly detection – max_abs_z: %s, iso_max: %s, final score: %s",
+        max_abs_z,
+        iso_max,
+        anomaly_score,
+    )
+    return {"anomaly_score": anomaly_score}

--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -31,6 +31,7 @@ from . import timing
 from . import openings
 from . import endgame
 from . import longitudinal
+from . import anomaly
 from app import models
 from app.database import engine
 from app.analysis.openings import aggregate_player_opening_patterns
@@ -305,12 +306,18 @@ class ChessAnalysisEngine:
             else:
                 logger.info("DEBUG ENGINE: Skipping endgame analysis - no tablebases or not endgame")
 
+            # 5.5 ANOMALY DETECTION
+            logger.info("DEBUG ENGINE: Starting anomaly analysis")
+            anomaly_features = anomaly.aggregate_anomaly_features(moves_df)
+            logger.info(f"DEBUG ENGINE: Anomaly features: {anomaly_features}")
+
             # 5. COMBINAR TODAS LAS FEATURES
             all_features = {
                 **quality_features,
                 **timing_features,
                 **opening_features,
-                **endgame_features
+                **endgame_features,
+                **anomaly_features,
             }
             logger.info(f"DEBUG ENGINE: Combined features count: {len(all_features)}")
             logger.info(f"DEBUG ENGINE: All features: {all_features}")
@@ -345,6 +352,8 @@ class ChessAnalysisEngine:
                 # Endgame
                 tb_match_rate=all_features.get('tb_match_pct'),
                 conversion_efficiency=all_features.get('conversion_moves'),
+                # Anomaly
+                anomaly_score=all_features.get('anomaly_score', 0),
                 # Flags (legacy fields kept for compatibility)
                 suspicious_quality=False,
                 suspicious_timing=False,

--- a/app/api/v1/endpoints/analysis.py
+++ b/app/api/v1/endpoints/analysis.py
@@ -40,6 +40,7 @@ async def get_game_metrics(game_id: int, session: Session = Depends(get_session)
         "mean_move_time": detailed.mean_move_time,
         "time_variance": detailed.time_variance,
         "time_complexity_corr": detailed.time_complexity_corr,
+        "anomaly_score": detailed.anomaly_score,
         "suspicion_score": detailed.overall_suspicion_score,
         "analyzed_at": detailed.analyzed_at.isoformat()
     }

--- a/app/models.py
+++ b/app/models.py
@@ -103,6 +103,9 @@ class GameAnalysisDetailed(SQLModel, table=True):
     dtz_deviation: Optional[float] = Field(default=None, description="Desviación DTZ promedio")
     conversion_efficiency: Optional[int] = Field(default=None, description="Movimientos para convertir ventaja")
 
+    # === ANOMALY METRICS ===
+    anomaly_score: float = Field(default=0, description="Score de detección de anomalías")
+
     # === FLAGS & SCORES ===
     suspicious_quality: bool = Field(default=False)
     suspicious_timing: bool = Field(default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -475,6 +475,7 @@ class GameMetricsOut(BaseModel):
     mean_move_time: float
     time_variance: float
     time_complexity_corr: float
+    anomaly_score: float
     suspicion_score: float = Field(alias="overall_suspicion_score")
     analyzed_at: datetime
 
@@ -493,6 +494,7 @@ class GameMetricsOut(BaseModel):
                 "mean_move_time": 12.5,
                 "time_variance": 30.2,
                 "time_complexity_corr": 0.45,
+                "anomaly_score": 1.5,
                 "suspicion_score": 0.12,
                 "analyzed_at": "2024-06-28T15:00:00Z"
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests~=2.32.3
 pandas~=2.3.0
 numpy~=2.3.0
 scikit-learn
+statsmodels>=0.14
 celery_once
 redis
 stockfish


### PR DESCRIPTION
## Summary
- add `anomaly.py` with STL residual z-score and Isolation Forest utilities
- integrate anomaly score into game analysis and API output
- expose anomaly_score field in models and schemas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac119692508332aad7b2549093c667