### PR TITLE
Add clustering for player profiles

### DIFF
--- a/app/analysis/__init__.py
+++ b/app/analysis/__init__.py
@@ -8,6 +8,7 @@ from . import timing
 from . import openings
 from . import endgame
 from . import longitudinal
+from . import clustering
 from . import spc
 from . import anomaly
 from .engine import ChessAnalysisEngine, prepare_moves_dataframe
@@ -19,6 +20,7 @@ from .openings  import aggregate_opening_features
 from .endgame   import aggregate_endgame_features
 from .anomaly   import aggregate_anomaly_features
 from .spc       import compute_spc
+from .clustering import assign_cluster_from_values, recompute_and_update_clusters
 
 __all__ = [
     'quality',
@@ -26,6 +28,7 @@ __all__ = [
     'openings',
     'endgame',
     'longitudinal',
+    'clustering',
     'spc',
     'anomaly',
     'prepare_moves_dataframe',
@@ -36,6 +39,8 @@ __all__ = [
     'aggregate_endgame_features',
     'aggregate_anomaly_features',
     'compute_spc',
+    'assign_cluster_from_values',
+    'recompute_and_update_clusters',
     'fit_performance_model',
     'predict_performance',
 ]

--- a/app/analysis/clustering.py
+++ b/app/analysis/clustering.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+"""Utilities for unsupervised clustering of player profiles.
+
+This module builds feature vectors from aggregated metrics and fits both
+KMeans and Gaussian Mixture Models (GMM).  It also provides helpers to assign
+an individual player to the nearest cluster and measure the distance to its
+centroid.  Trained models are persisted under ``models/clustering`` so they can
+be reused by subsequent analyses.
+"""
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.mixture import GaussianMixture
+from sqlmodel import Session, select
+
+from app.database import engine
+from app.models import PlayerAnalysisDetailed
+
+# Directory where clustering models are stored
+MODEL_DIR = Path(__file__).resolve().parents[2] / "models" / "clustering"
+
+
+# ---------------------------------------------------------------------------
+# Feature engineering
+# ---------------------------------------------------------------------------
+def _to_frame(rows: Iterable[Tuple[float, float, float]]) -> pd.DataFrame:
+    """Convert an iterable of raw tuples to a DataFrame.
+
+    Each tuple is ``(mean_move_time, avg_acpl, mean_entropy)``.
+    """
+
+    return pd.DataFrame(rows, columns=["mean_move_time", "avg_acpl", "mean_entropy"])
+
+
+def fit_models(df: pd.DataFrame, k: int = 3) -> Tuple[KMeans, GaussianMixture]:
+    """Fit KMeans and GMM models over ``df`` and return them."""
+
+    kmeans = KMeans(n_clusters=k, random_state=42)
+    kmeans.fit(df)
+
+    gmm = GaussianMixture(n_components=k, random_state=42)
+    gmm.fit(df)
+
+    return kmeans, gmm
+
+
+def assign_cluster_from_values(
+    *, avg_acpl: float, mean_move_time: float, mean_entropy: float
+) -> Tuple[int, float]:
+    """Assign a player to a cluster using stored KMeans model.
+
+    Returns a tuple ``(cluster_id, distance_to_center)``.  If no trained model is
+    available, ``(-1, 0.0)`` is returned.
+    """
+
+    model_path = MODEL_DIR / "kmeans.joblib"
+    if not model_path.exists():
+        return -1, 0.0
+
+    kmeans: KMeans = joblib.load(model_path)
+    features = _to_frame([(mean_move_time, avg_acpl, mean_entropy)])
+    cluster_id = int(kmeans.predict(features)[0])
+    center = kmeans.cluster_centers_[cluster_id]
+    distance = float(np.linalg.norm(features.values[0] - center))
+    return cluster_id, distance
+
+
+def recompute_and_update_clusters(k: int = 3) -> None:
+    """Re-train clustering models with all players and update assignments."""
+
+    with Session(engine) as session:
+        players = session.exec(select(PlayerAnalysisDetailed)).all()
+
+        rows: list[Tuple[float, float, float]] = []
+        usernames: list[str] = []
+        for p in players:
+            mean_time = (p.time_management or {}).get("mean_move_time")
+            mean_entropy = (p.opening_patterns or {}).get("mean_entropy")
+            if mean_time is None or mean_entropy is None or p.avg_acpl is None:
+                continue
+            rows.append((mean_time, p.avg_acpl, mean_entropy))
+            usernames.append(p.username)
+
+        if not rows:
+            return
+
+        df = _to_frame(rows)
+        MODEL_DIR.mkdir(parents=True, exist_ok=True)
+        kmeans, gmm = fit_models(df, k=k)
+        joblib.dump(kmeans, MODEL_DIR / "kmeans.joblib")
+        joblib.dump(gmm, MODEL_DIR / "gmm.joblib")
+
+        clusters = kmeans.predict(df)
+        centers = kmeans.cluster_centers_
+        distances = np.linalg.norm(df.values - centers[clusters], axis=1)
+
+        for username, cid, dist in zip(usernames, clusters, distances):
+            player = session.get(PlayerAnalysisDetailed, username)
+            if player:
+                player.cluster_id = int(cid)
+                player.cluster_distance = float(dist)
+        session.commit()

--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -38,6 +38,7 @@ from app.analysis.openings import aggregate_player_opening_patterns
 from app.utils import clean_json_numbers
 from app.analysis.eco_table import ECO_NAMES
 from app.analysis.longitudinal import compute_trends
+from .clustering import assign_cluster_from_values
 from app.analysis.quality import compute_phase_quality
 import numpy as np
 from app.analysis.benchmark import compute_benchmark
@@ -539,6 +540,14 @@ class ChessAnalysisEngine:
             time_feats = aggregate_time_management(moves_dfs)
             long_features["time_management"] = time_feats
 
+            cluster_id, cluster_dist = assign_cluster_from_values(
+                avg_acpl=_safe_mean(games_df, "acpl"),
+                mean_move_time=time_feats.get("mean_move_time", 0.0),
+                mean_entropy=opening_feats.get("mean_entropy", 0.0),
+            )
+            long_features["cluster_id"] = cluster_id
+            long_features["distance_to_center"] = cluster_dist
+
             # 2. games_df lo tienes al principio:
             clutch_feats = aggregate_clutch_accuracy(games_df)
             long_features["clutch_accuracy"] = clutch_feats
@@ -606,6 +615,8 @@ class ChessAnalysisEngine:
                 endgame=endgame_feats,
                 segments=segments,
                 change_points=change_points,
+                cluster_id=long_features.get("cluster_id"),
+                cluster_distance=long_features.get("distance_to_center"),
                 # ─ Riesgo ─
                 risk_score=risk_score,
                 risk_factors=risk_factors,

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -57,9 +57,11 @@ from app.analysis import (
     aggregate_endgame_features as e_feats,
 )
 from app.analysis.bayesian import BayesianSuspicionModel
+from app.analysis.clustering import recompute_and_update_clusters
 
 from kombu import Queue  # Añadido para configurar colas con prioridad
 from celery.exceptions import SoftTimeLimitExceeded
+from celery.schedules import crontab
 
 # Configuración de prioridades (0 = más alta)
 HIGH_PRIORITY   = 0
@@ -885,3 +887,19 @@ def test_worker_functionality():
     import time
     time.sleep(0.1)
     return {"status": "success", "message": "Worker functionality verified"}
+
+
+@celery_app.task(name="recalculate_player_clusters")
+def recalculate_player_clusters():
+    """Periodic task to recompute clustering models and update players."""
+    recompute_and_update_clusters()
+    return {"status": "ok"}
+
+
+@celery_app.on_after_configure.connect
+def setup_cluster_schedule(sender, **kwargs):
+    sender.add_periodic_task(
+        crontab(hour=0, minute=0),
+        recalculate_player_clusters.s(),
+        name="recalculate-clusters-daily",
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -237,6 +237,8 @@ class PlayerAnalysisDetailed(SQLModel, table=True):
     time_complexity: Dict | None = Field(sa_column=Column(JSON, default=dict))
     segments: list[Dict] = Field(sa_column=Column(JSON, default=list))
     change_points: list[int] = Field(sa_column=Column(JSON, default=list))
+    cluster_id: int | None = Field(default=None, nullable=True)
+    cluster_distance: float | None = Field(default=None, nullable=True)
     # back-ref al jugador
     player: Optional[Player] = Relationship(back_populates="analysis")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -252,6 +252,8 @@ class PlayerMetricsOut(BaseModel):
     peer_delta_acpl: float
     peer_delta_match: float
     longest_streak: int
+    cluster_id: Optional[int] = None
+    distance_to_center: Optional[float] = None
     first_game_date: Optional[datetime] = None
     last_game_date: Optional[datetime] = None
 
@@ -518,6 +520,8 @@ class PlayerMetricsSummaryOut(BaseModel):
     peer_delta_match: float
     longest_streak: int
     selectivity_score: float
+    cluster_id: Optional[int] = None
+    distance_to_center: Optional[float] = None
 
     class Config:
         orm_mode = True

--- a/migrations/0003_add_cluster_columns.sql
+++ b/migrations/0003_add_cluster_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE player_analysis_detailed ADD COLUMN cluster_id INTEGER;
+ALTER TABLE player_analysis_detailed ADD COLUMN cluster_distance FLOAT;


### PR DESCRIPTION
## Summary
- implement KMeans and GMM clustering for player statistics
- store cluster id and distance in player longitudinal metrics
- schedule periodic task to refresh clusters with new data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac15ead4208332868edf0756a99ce3