### PR TITLE
Add causal fairness metrics and API integration

### DIFF
--- a/app/analysis/causal_fairness.py
+++ b/app/analysis/causal_fairness.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pandas as pd
+from typing import Dict, Iterable, Any
+
+
+def difference_in_differences(
+    df: pd.DataFrame,
+    group_col: str,
+    time_col: str,
+    outcome_col: str,
+    treated_value: Any,
+    pre_period: Any,
+    post_period: Any,
+) -> float:
+    """Compute classic difference-in-differences estimator.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Dataset containing group, time and outcome columns.
+    group_col : str
+        Column indicating treatment vs control groups.
+    time_col : str
+        Column with time period labels.
+    outcome_col : str
+        Outcome variable column.
+    treated_value : Any
+        Value in ``group_col`` that identifies the treated group.
+    pre_period, post_period : Any
+        Values in ``time_col`` defining the pre and post periods.
+
+    Returns
+    -------
+    float
+        Estimated causal effect using difference-in-differences.
+    """
+
+    treated_pre = df[(df[group_col] == treated_value) & (df[time_col] == pre_period)][
+        outcome_col
+    ].mean()
+    treated_post = df[(df[group_col] == treated_value) & (df[time_col] == post_period)][
+        outcome_col
+    ].mean()
+    control_pre = df[(df[group_col] != treated_value) & (df[time_col] == pre_period)][
+        outcome_col
+    ].mean()
+    control_post = df[(df[group_col] != treated_value) & (df[time_col] == post_period)][
+        outcome_col
+    ].mean()
+    return float((treated_post - treated_pre) - (control_post - control_pre))
+
+
+def demographic_parity(y_pred: Iterable[int], sensitive: Iterable[Any]) -> Dict[str, Any]:
+    """Demographic parity difference across sensitive groups.
+
+    Returns a dict with per-group positive prediction rates and the
+    maximum absolute difference between groups.
+    """
+    y_pred_arr = np.asarray(list(y_pred))
+    sensitive_arr = np.asarray(list(sensitive))
+    groups = np.unique(sensitive_arr)
+    positive_rates = {g: float(y_pred_arr[sensitive_arr == g].mean()) for g in groups}
+    diff = max(positive_rates.values()) - min(positive_rates.values())
+    return {"positive_rates": positive_rates, "parity_diff": float(diff)}
+
+
+def equalized_odds(
+    y_true: Iterable[int],
+    y_pred: Iterable[int],
+    sensitive: Iterable[Any],
+) -> Dict[str, Any]:
+    """Equalized odds differences across groups.
+
+    Computes true positive rate (TPR) and false positive rate (FPR) for
+    each sensitive group and returns the maximum difference between
+    groups for both metrics.
+    """
+    y_true_arr = np.asarray(list(y_true))
+    y_pred_arr = np.asarray(list(y_pred))
+    sensitive_arr = np.asarray(list(sensitive))
+    groups = np.unique(sensitive_arr)
+    metrics: Dict[Any, Dict[str, float]] = {}
+    tprs = []
+    fprs = []
+    for g in groups:
+        mask = sensitive_arr == g
+        tp = np.sum((y_pred_arr == 1) & (y_true_arr == 1) & mask)
+        fn = np.sum((y_pred_arr == 0) & (y_true_arr == 1) & mask)
+        fp = np.sum((y_pred_arr == 1) & (y_true_arr == 0) & mask)
+        tn = np.sum((y_pred_arr == 0) & (y_true_arr == 0) & mask)
+        tpr = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        fpr = fp / (fp + tn) if (fp + tn) > 0 else 0.0
+        metrics[g] = {"tpr": float(tpr), "fpr": float(fpr)}
+        tprs.append(tpr)
+        fprs.append(fpr)
+    return {
+        "group_metrics": metrics,
+        "tpr_diff": float(max(tprs) - min(tprs)),
+        "fpr_diff": float(max(fprs) - min(fprs)),
+    }
+
+
+def check_fairness_thresholds(
+    y_true: Iterable[int],
+    y_pred: Iterable[int],
+    sensitive: Iterable[Any],
+    thresholds: Dict[str, float],
+) -> Dict[str, float]:
+    """Validate fairness metrics against provided thresholds.
+
+    Parameters
+    ----------
+    thresholds : Dict[str, float]
+        Expected keys are ``"demographic_parity"`` and
+        ``"equalized_odds"`` representing maximum allowed differences.
+
+    Returns
+    -------
+    Dict[str, float]
+        Calculated fairness metrics.
+
+    Raises
+    ------
+    ValueError
+        If any metric exceeds its threshold.
+    """
+    dp = demographic_parity(y_pred, sensitive)["parity_diff"]
+    eo = equalized_odds(y_true, y_pred, sensitive)
+    max_eo = max(abs(eo["tpr_diff"]), abs(eo["fpr_diff"]))
+    dp_thr = thresholds.get("demographic_parity", 0.1)
+    eo_thr = thresholds.get("equalized_odds", 0.1)
+    if abs(dp) > dp_thr or max_eo > eo_thr:
+        raise ValueError("Fairness thresholds exceeded")
+    return {
+        "demographic_parity": dp,
+        "equalized_odds_tpr_diff": eo["tpr_diff"],
+        "equalized_odds_fpr_diff": eo["fpr_diff"],
+    }

--- a/app/analysis/ml_classifier.py
+++ b/app/analysis/ml_classifier.py
@@ -19,6 +19,11 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
+try:  # pragma: no cover - fallback for standalone usage
+    from .causal_fairness import check_fairness_thresholds
+except Exception:  # ImportError in non-package execution
+    from causal_fairness import check_fairness_thresholds  # type: ignore
+
 
 MODEL_FILENAME = "ml_suspicion_model.pkl"
 
@@ -55,6 +60,8 @@ class MLSuspicionClassifier:
         y: Iterable[int],
         model_type: str = "random_forest",
         cv: int = 5,
+        sensitive_features: Optional[Iterable[int]] = None,
+        fairness_thresholds: Optional[Dict[str, float]] = None,
     ) -> Dict[str, float]:
         """Train the classifier and persist it to disk.
 
@@ -68,10 +75,15 @@ class MLSuspicionClassifier:
             Either ``"random_forest"`` or ``"gradient_boosting"``.
         cv:
             Number of folds for cross-validation.
+        sensitive_features:
+            Optional iterable with sensitive group labels aligned with ``y``.
+        fairness_thresholds:
+            Thresholds for fairness metrics. If provided, demographic
+            parity and equalized odds will be computed and validated.
 
         Returns
         -------
-        Dict with cross-validation statistics.
+        Dict with cross-validation and (optionally) fairness statistics.
         """
 
         if model_type == "gradient_boosting":
@@ -99,7 +111,22 @@ class MLSuspicionClassifier:
         self.model_path.parent.mkdir(parents=True, exist_ok=True)
         joblib.dump({"model": self.model, "features": self.feature_names}, self.model_path)
 
-        return {"cv_mean": float(scores.mean()), "cv_std": float(scores.std())}
+        result: Dict[str, float] = {
+            "cv_mean": float(scores.mean()),
+            "cv_std": float(scores.std()),
+        }
+
+        if sensitive_features is not None:
+            preds = pipeline.predict(X)
+            metrics = check_fairness_thresholds(
+                y,
+                preds,
+                sensitive_features,
+                fairness_thresholds or {},
+            )
+            result.update(metrics)
+
+        return result
 
     # ------------------------------------------------------------------
     def predict_proba(self, features: Dict[str, float]) -> float:

--- a/app/api/v1/endpoints/analysis.py
+++ b/app/api/v1/endpoints/analysis.py
@@ -5,7 +5,13 @@ from sqlmodel import Session
 from app import models
 from app.database import get_session
 from app.analysis.engine import ChessAnalysisEngine
-from app.schemas import GameMetricsOut, PlayerMetricsSummaryOut
+from app.analysis.causal_fairness import demographic_parity, equalized_odds
+from app.schemas import (
+    GameMetricsOut,
+    PlayerMetricsSummaryOut,
+    FairnessMetricsIn,
+    FairnessMetricsOut,
+)
 
 router = APIRouter()
 
@@ -83,3 +89,23 @@ async def get_player_metrics(
         "longest_streak": analysis.longest_streak,
         "selectivity_score": analysis.selectivity_score
     }
+
+
+@router.post(
+    "/metrics/fairness",
+    response_model=FairnessMetricsOut,
+    summary="Calcular métricas de fairness",
+    description=(
+        "Calcula diferencias de demographic parity y equalized odds para las "
+        "predicciones proporcionadas."
+    ),
+)
+async def compute_fairness_metrics(payload: FairnessMetricsIn) -> FairnessMetricsOut:
+    """Compute fairness metrics for given predictions and sensitive groups."""
+    dp = demographic_parity(payload.y_pred, payload.sensitive_features)["parity_diff"]
+    eo = equalized_odds(payload.y_true, payload.y_pred, payload.sensitive_features)
+    return FairnessMetricsOut(
+        demographic_parity=dp,
+        equalized_odds_tpr_diff=eo["tpr_diff"],
+        equalized_odds_fpr_diff=eo["fpr_diff"],
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -747,6 +747,22 @@ class TaskResultOut(BaseModel):
         }
 
 
+class FairnessMetricsIn(BaseModel):
+    """Input payload for fairness metric calculation."""
+
+    y_true: List[int]
+    y_pred: List[int]
+    sensitive_features: List[Any]
+
+
+class FairnessMetricsOut(BaseModel):
+    """Fairness metrics returned by the API."""
+
+    demographic_parity: float
+    equalized_odds_tpr_diff: float
+    equalized_odds_fpr_diff: float
+
+
 __all__ = [
     "PlayerMetricsOut",
     "TimePatternsOut",
@@ -768,4 +784,6 @@ __all__ = [
     "TaskStatusOut",
     "TaskCancelOut",
     "TaskResultOut",
+    "FairnessMetricsIn",
+    "FairnessMetricsOut",
 ]

--- a/docs/fairness.md
+++ b/docs/fairness.md
@@ -1,0 +1,17 @@
+# Fairness Monitoring
+
+El sistema calcula métricas de sesgo para las predicciones de los modelos:
+
+- **Demographic Parity**: diferencia máxima en la tasa de positivos entre grupos.
+- **Equalized Odds**: diferencia máxima de TPR y FPR entre grupos.
+
+Umbrales recomendados:
+
+| Métrica | Umbral |
+|---------|--------|
+| Demographic Parity | ≤ 0.10 |
+| Equalized Odds (TPR/FPR) | ≤ 0.10 |
+
+Durante el entrenamiento, el pipeline valida automáticamente que las
+métricas anteriores no superen estos límites y lanza un error en caso
+contrario.

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,59 @@
+import os
+import pathlib
+import sys
+
+import pandas as pd
+import pytest
+
+analysis_dir = pathlib.Path(__file__).resolve().parents[1] / "app" / "analysis"
+sys.path.insert(0, str(analysis_dir))
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("DB_MAX_RETRIES", "1")
+
+from causal_fairness import demographic_parity, equalized_odds
+from ml_classifier import MLSuspicionClassifier
+
+
+def test_fairness_metrics_basic():
+    y_true = [1, 0, 1, 0, 1, 0, 1, 0]
+    y_pred = [1, 0, 1, 0, 0, 0, 1, 1]
+    sensitive = ["A", "A", "A", "A", "B", "B", "B", "B"]
+
+    dp = demographic_parity(y_pred, sensitive)
+    eo = equalized_odds(y_true, y_pred, sensitive)
+
+    assert dp["parity_diff"] >= 0
+    assert "tpr_diff" in eo and "fpr_diff" in eo
+
+
+def test_training_pipeline_checks_fairness():
+    X = pd.DataFrame({
+        "f1": [0, 1, 0, 1, 0, 1, 0, 1],
+        "f2": [1, 0, 1, 0, 1, 0, 1, 0],
+    })
+    y = [0, 1, 0, 1, 0, 1, 0, 1]
+    sensitive = [0, 0, 0, 0, 1, 1, 1, 1]
+
+    clf = MLSuspicionClassifier()
+    # Should pass with relaxed thresholds
+    stats = clf.train(
+        X,
+        y,
+        model_type="gradient_boosting",
+        cv=2,
+        sensitive_features=sensitive,
+        fairness_thresholds={"demographic_parity": 1.0, "equalized_odds": 1.0},
+    )
+    assert "demographic_parity" in stats
+    from causal_fairness import check_fairness_thresholds
+
+    # Artificially biased predictions to trigger failure
+    biased_preds = [1, 1, 1, 1, 0, 0, 0, 0]
+
+    with pytest.raises(ValueError):
+        check_fairness_thresholds(
+            y,
+            biased_preds,
+            sensitive,
+            {"demographic_parity": 0.0},
+        )


### PR DESCRIPTION
## Summary
- implement causal_fairness module with difference-in-differences, demographic parity, equalized odds and threshold checks
- expose fairness metrics endpoint and schemas in API
- validate fairness during model training and document acceptable thresholds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac776103b0833293dafc9683c3a89b