### PR TITLE
Track player progress via done_tasks

### DIFF
--- a/alembic/versions/e5b8c71b3f2c_add_done_tasks_to_player.py
+++ b/alembic/versions/e5b8c71b3f2c_add_done_tasks_to_player.py
@@ -1,0 +1,24 @@
+"""add_done_tasks_to_player
+
+Revision ID: e5b8c71b3f2c
+Revises: a1b2c3d4e5f6
+Create Date: 2025-08-23 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e5b8c71b3f2c'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('player', sa.Column('done_tasks', sa.Integer(), nullable=True))
+    op.execute("UPDATE player SET done_tasks = COALESCE(done_games, 0) * 2")
+
+
+def downgrade() -> None:
+    op.drop_column('player', 'done_tasks')

--- a/app/api/v1/endpoints/players.py
+++ b/app/api/v1/endpoints/players.py
@@ -40,7 +40,7 @@ async def get_player(username: str, session: Session = Depends(get_session)):
         "status": player.status,
         "progress": player.progress,
         "total_games": player.total_games,
-        "done_games": player.done_games,
+        "done_games": (player.done_tasks or 0) // 2,
         "requested_at": player.requested_at.isoformat() if player.requested_at else None,
         "finished_at": player.finished_at.isoformat() if player.finished_at else None,
         "error": player.error,
@@ -72,12 +72,14 @@ async def analyze_player(
             }
             
         if not player:
-            player = models.Player(username=username, status="pending")
+            player = models.Player(username=username, status="pending", done_tasks=0, done_games=0)
             session.add(player)
         else:
             player.status = "pending"
             player.progress = 0
             player.error = None
+            player.done_tasks = 0
+            player.done_games = 0
             
         player.requested_at = datetime.now(timezone.utc)
         player.finished_at = None
@@ -134,7 +136,7 @@ async def list_players(
             "status": p.status,
             "progress": p.progress,
             "total_games": p.total_games,
-            "done_games": p.done_games,
+            "done_games": (p.done_tasks or 0) // 2,
             "requested_at": p.requested_at.isoformat() if p.requested_at else None,
             "finished_at": p.finished_at.isoformat() if p.finished_at else None,
         }

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -742,6 +742,7 @@ def process_player_enhanced(self, username: str, months: int = 12, priority: int
                 requested_at=datetime.now(timezone.utc),
                 progress=0,
                 total_games=len(games),
+                done_tasks=0,
                 done_games=0,
             )
             s.add(player)
@@ -750,6 +751,7 @@ def process_player_enhanced(self, username: str, months: int = 12, priority: int
             player.requested_at = datetime.now(timezone.utc)
             player.progress = 0
             player.total_games = len(games)
+            player.done_tasks = 0
             player.done_games = 0
         s.commit()
         logger.info(f"DEBUG CELERY: Created/updated player record for {username}")

--- a/app/main.py
+++ b/app/main.py
@@ -400,7 +400,7 @@ def get_player(username: str, session: Session = Depends(get_session)):
         "status": player.status,
         "progress": player.progress,
         "total_games": player.total_games,
-        "done_games": player.done_games,
+        "done_games": (player.done_tasks or 0) // 2,
         "requested_at": player.requested_at.isoformat() if player.requested_at else None,
         "finished_at": player.finished_at.isoformat() if player.finished_at else None,
         "error": player.error,
@@ -481,6 +481,7 @@ def analyze_player(
             now = datetime.now(UTC)
             player.status = models.PlayerStatus.pending
             player.progress = 0
+            player.done_tasks = 0
             player.done_games = 0
             player.total_games = 0
             player.requested_at = now
@@ -563,7 +564,7 @@ def list_players(
             "status": p.status,
             "progress": p.progress,
             "total_games": p.total_games,
-            "done_games": p.done_games,
+            "done_games": (p.done_tasks or 0) // 2,
             "requested_at": p.requested_at.isoformat() if p.requested_at else None,
             "finished_at": p.finished_at.isoformat() if p.finished_at else None,
         }
@@ -906,6 +907,7 @@ def reset_player(username: str, session: Session = Depends(get_session)):
     player.status = models.PlayerStatus.not_analyzed
     player.progress = 0
     player.total_games = None
+    player.done_tasks = None
     player.done_games = None
     player.requested_at = None
     player.finished_at = None

--- a/app/models.py
+++ b/app/models.py
@@ -148,6 +148,7 @@ class Player(SQLModel, table=True):
     finished_at: datetime | None = Field(default=None)
     progress: int = Field(default=0)
     total_games: int = Field(default=0)
+    done_tasks: int = Field(default=0)
     done_games: int = Field(default=0)
 
     error: str | None = Field(

--- a/app/utils.py
+++ b/app/utils.py
@@ -146,11 +146,12 @@ def update_progress(username: str, *, increment: int = 1) -> None:
         if not pl:
             return
 
-        pl.done_games = (pl.done_games or 0) + increment
+        pl.done_tasks = (pl.done_tasks or 0) + increment
+        pl.done_games = pl.done_tasks // 2
         expected = (pl.total_games or 0) * 2  # básico + detallado
-        pl.progress = int(pl.done_games / expected * 100) if expected else 0
+        pl.progress = int(pl.done_tasks / expected * 100) if expected else 0
 
-        if expected and pl.done_games >= expected:
+        if expected and pl.done_tasks >= expected:
             pl.status = "ready"
             pl.finished_at = datetime.now(UTC)
 


### PR DESCRIPTION
## Summary
- add done_tasks field and migration to Player model
- derive done_games from done_tasks and recompute progress
- expose calculated done_games in player API and main routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac86b4693c8332a1969bcb5d7ef177