### PR TITLE
Add GARCH performance modeling with auto-selection and confidence intervals

### DIFF
--- a/app/analysis/performance_model.py
+++ b/app/analysis/performance_model.py
@@ -1,9 +1,44 @@
 import numpy as np
 import pandas as pd
-from typing import Dict
+from typing import Dict, Tuple
 
 
-def fit_performance_model(series: pd.Series, model: str = "arima") -> Dict[str, float]:
+def fit_garch_model(series: pd.Series) -> Dict[str, float]:
+    """Fit a rudimentary GARCH(1,1) model.
+
+    This implementation is intentionally lightweight and avoids external
+    dependencies.  Parameters are estimated using basic moment
+    approximations rather than full maximum likelihood estimation.
+    """
+
+    s = pd.Series(series).dropna().astype(float)
+    if len(s) < 2:
+        raise ValueError("series must contain at least two observations")
+
+    resid = s - s.mean()
+    var = float(np.var(resid, ddof=1)) or 1e-6
+
+    # Simple moment-based parameter guesses
+    alpha = 0.1
+    beta = 0.8
+    omega = max(var * (1 - alpha - beta), 1e-6)
+
+    sigma2 = var
+    for r in resid:
+        sigma2 = omega + alpha * r ** 2 + beta * sigma2
+
+    return {
+        "model": "garch",
+        "omega": float(omega),
+        "alpha": float(alpha),
+        "beta": float(beta),
+        "last": float(s.iloc[-1]),
+        "last_var": float(sigma2),
+        "last_resid_sq": float(resid.iloc[-1] ** 2),
+    }
+
+
+def fit_performance_model(series: pd.Series, model: str = "auto") -> Dict[str, float]:
     """Fit a simple time-series model for performance metrics.
 
     Parameters
@@ -11,7 +46,8 @@ def fit_performance_model(series: pd.Series, model: str = "arima") -> Dict[str, 
     series : pd.Series
         Series of historical metric values (ACPL, ROI, etc.).
     model : str
-        Type of model to fit. Options: ``"arima"`` or ``"kalman"``.
+        Type of model to fit. Options: ``"arima"``, ``"kalman"``, ``"garch"`` or
+        ``"auto"`` for automatic selection based on volatility.
 
     Returns
     -------
@@ -21,6 +57,15 @@ def fit_performance_model(series: pd.Series, model: str = "arima") -> Dict[str, 
     s = pd.Series(series).dropna().astype(float)
     if s.empty:
         raise ValueError("series must contain data")
+
+    if model == "auto":
+        vol = float(np.std(s.diff().dropna())) if len(s) > 1 else 0.0
+        if vol > 1.0:
+            model = "garch"
+        elif vol > 0.1:
+            model = "arima"
+        else:
+            model = "kalman"
 
     if model == "arima":
         if len(s) < 2:
@@ -44,12 +89,27 @@ def fit_performance_model(series: pd.Series, model: str = "arima") -> Dict[str, 
             p = (1 - k) * p
         return {"model": "kalman", "state": float(x), "p": float(p), "q": float(q), "r": float(r)}
 
-    raise ValueError("model must be 'arima' or 'kalman'")
+    if model == "garch":
+        return fit_garch_model(s)
+
+    raise ValueError("model must be 'arima', 'kalman', 'garch' or 'auto'")
 
 
-def predict_performance(model: Dict[str, float], steps: int = 1) -> np.ndarray:
-    """Generate forward predictions from a fitted model."""
+def predict_performance(
+    model: Dict[str, float],
+    steps: int = 1,
+    return_conf_int: bool = False,
+) -> np.ndarray | Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Generate forward predictions from a fitted model.
+
+    For GARCH models, if ``return_conf_int`` is True a tuple of
+    ``(preds, lower, upper)`` arrays is returned representing 95%
+    confidence bands.
+    """
+
     if model.get("model") == "arima":
+        if return_conf_int:
+            raise ValueError("confidence intervals only available for garch models")
         last = model["last"]
         phi = model["phi"]
         c = model["c"]
@@ -60,7 +120,29 @@ def predict_performance(model: Dict[str, float], steps: int = 1) -> np.ndarray:
         return np.array(preds)
 
     if model.get("model") == "kalman":
+        if return_conf_int:
+            raise ValueError("confidence intervals only available for garch models")
         state = model["state"]
         return np.full(steps, state)
+
+    if model.get("model") == "garch":
+        last = model["last"]
+        omega = model["omega"]
+        alpha = model["alpha"]
+        beta = model["beta"]
+        var = model["last_var"]
+        resid_sq = model.get("last_resid_sq", 0.0)
+        preds, lower, upper = [], [], []
+        for _ in range(steps):
+            var = omega + alpha * resid_sq + beta * var
+            resid_sq = 0.0
+            preds.append(last)
+            ci = 1.96 * np.sqrt(var)
+            lower.append(last - ci)
+            upper.append(last + ci)
+        preds = np.array(preds)
+        if return_conf_int:
+            return preds, np.array(lower), np.array(upper)
+        return preds
 
     raise ValueError("unknown model type")

--- a/tests/test_garch_model.py
+++ b/tests/test_garch_model.py
@@ -1,0 +1,36 @@
+import os
+import pathlib
+import sys
+
+import numpy as np
+import pandas as pd
+
+analysis_dir = pathlib.Path(__file__).resolve().parents[1] / "app" / "analysis"
+sys.path.insert(0, str(analysis_dir))
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("DB_MAX_RETRIES", "1")
+
+from performance_model import fit_performance_model, predict_performance
+
+
+def test_garch_prediction_conf_int():
+    np.random.seed(0)
+    series = pd.Series(np.random.normal(scale=1.5, size=200))
+    model = fit_performance_model(series, model="garch")
+    preds, lower, upper = predict_performance(model, steps=5, return_conf_int=True)
+    assert preds.shape == (5,)
+    assert lower.shape == (5,)
+    assert upper.shape == (5,)
+    assert np.all(upper > lower)
+
+
+def test_auto_model_selection():
+    np.random.seed(1)
+    high_vol = pd.Series(np.random.normal(scale=5.0, size=100))
+    low_vol = pd.Series(np.linspace(1, 1.1, 100))
+
+    model_high = fit_performance_model(high_vol, model="auto")
+    model_low = fit_performance_model(low_vol, model="auto")
+
+    assert model_high["model"] == "garch"
+    assert model_low["model"] == "kalman"


### PR DESCRIPTION
## Summary
- implement lightweight `fit_garch_model` and extend `fit_performance_model` to auto-select between ARIMA, Kalman, and GARCH based on volatility
- support GARCH predictions with optional 95% confidence intervals via `predict_performance`
- add tests covering GARCH fitting, prediction, and automatic model selection

## Testing
- `pytest tests/test_garch_model.py tests/test_fairness.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aebfbd4ff88332adf77d4eedea2db6